### PR TITLE
Adding tuple support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache___
 outputs/
 .idea/
 .venv/
+outputs/

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ __pycache___
 outputs/
 .idea/
 .venv/
-outputs/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache___
 *.pyc
 outputs/
 .idea/
+.venv/

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -3,7 +3,7 @@
 # specify here default preprocessing configuration
 defaults:
     # can be any config file in the preprocessing_pipeline folder
-    - preprocessing_pipeline: decision_tree.yaml
+    - preprocessing_pipeline: pca.yaml
 
 
 # You might add another configurations: which model to use, which visualizations, etc.

--- a/configs/preprocessing_pipeline/decision_tree.yaml
+++ b/configs/preprocessing_pipeline/decision_tree.yaml
@@ -17,4 +17,4 @@ steps_config: # use yaml list syntax to preserve to order
     - SimpleImputer:
         _target_: sklearn.impute.SimpleImputer
         strategy: 'constant'
-        fill_value: '-1'
+        fill_value: -1

--- a/configs/preprocessing_pipeline/logistic_regression.yaml
+++ b/configs/preprocessing_pipeline/logistic_regression.yaml
@@ -10,7 +10,7 @@ steps_config: # use yaml list syntax to preserve to order
     - SimpleImputer:
         _target_: sklearn.impute.SimpleImputer
         strategy: 'constant'
-        fill_value: '-1'
+        fill_value: -1
 
     - VarianceThreshold:
         _target_: sklearn.feature_selection.VarianceThreshold

--- a/configs/preprocessing_pipeline/pca.yaml
+++ b/configs/preprocessing_pipeline/pca.yaml
@@ -1,0 +1,19 @@
+# Hydra config file for the random_forest preprocessing steps
+_target_: hydra_sklearn_pipeline.make_pipeline
+
+#StepName:
+#    _target_: <class to instantiate the step>
+#    param1: <step's first parameter>
+#    param2: <step's second parameter, etc.>
+
+steps_config: # use yaml list syntax to preserve to order 
+    - MinMaxScaler:
+        _target_: sklearn.preprocessing.MinMaxScaler
+        clip: true
+        # feature_range: (1, 2)  # interpreted as str
+        # feature_range: [1, 2]  # not a tuple
+        feature_range: "${tuple:[3,4]}"
+
+    - PCA:
+        _target_: sklearn.decomposition.PCA
+        n_components: 5 

--- a/main.py
+++ b/main.py
@@ -2,11 +2,12 @@ import logging
 
 import hydra
 import numpy as np
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 import utils
 
 log = logging.getLogger(__name__)
+OmegaConf.register_new_resolver("tuple", lambda lst: tuple(lst))
 
 
 @hydra.main(config_path="configs/", config_name="config.yaml")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import logging
 
 import hydra
+import numpy as np
 from omegaconf import DictConfig
 
 import utils
@@ -10,7 +11,6 @@ log = logging.getLogger(__name__)
 
 @hydra.main(config_path="configs/", config_name="config.yaml")
 def main(config: DictConfig):
-
     # Pretty print config using Rich library
     if config.get("print_config"):
         utils.print_config(config, resolve=True)
@@ -20,6 +20,8 @@ def main(config: DictConfig):
         config.preprocessing_pipeline, _recursive_=False
     )
     print(type(preprocessing_pipeline))
+
+    preprocessing_pipeline.fit(np.random.random((10, 100)))
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-hydra-core=1.1
+hydra-core==1.1
 scikit-learn
 rich


### PR DESCRIPTION
By default, Hydra (OmegaConf) does not handle tuples.
On the other hand, some sklearn classes require tuples as input params.
Here I'm extending the example of using hydra.utils.instantiate together with sklearn by adding a custom resolver 'tuple' to enable passing tuple arguments.